### PR TITLE
Add dependencies to info.rkt

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,3 +1,5 @@
 #lang setup/infotab
 (define version "0.1")
 (define collection 'multi)
+(define deps '("base" "r6rs-lib"))
+(define build-deps '("racket-doc" "rackunit-lib" "scribble-lib"))


### PR DESCRIPTION
Add dependency metadata to info.rkt to suppress build warnings.
